### PR TITLE
Add a "the" before "ists"

### DIFF
--- a/lib/Acme/ConspiracyTheory/Random.pm
+++ b/lib/Acme/ConspiracyTheory/Random.pm
@@ -140,7 +140,7 @@ sub shady_group {
 	_MERGE_( $redstring, shady_group => $xx );
 	my $name = $xx->{name};
 	if ($name =~ /ists$/ && $name !~ /^the/) {
-	    $name = "the $name";
+		$name = "the $name";
 	}
 	return $name;
 }

--- a/lib/Acme/ConspiracyTheory/Random.pm
+++ b/lib/Acme/ConspiracyTheory/Random.pm
@@ -138,7 +138,11 @@ sub shady_group {
 	};
 	
 	_MERGE_( $redstring, shady_group => $xx );
-	return $xx->{name};
+	my $name = $xx->{name};
+	if ($name =~ /ists$/ && $name !~ /^the/) {
+	    $name = "the $name";
+	}
+	return $name;
 }
 
 sub real_animal {


### PR DESCRIPTION
I got this output:

"Joe Rogan is a member of feminists. The Trump administration were originally opposed to this but they're now in on it. I know because feminists have included it in their manifesto, and if you Google for feminists there's loads of info."

This just changes the first instance of the name to "the" for
"feminists", "Satanists", "Socialists" and "atheists".